### PR TITLE
fix(fs): robust project root resolution

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -203,6 +203,7 @@ Para maximizar la resiliencia y el razonamiento, se adoptan los siguientes está
 │   │   ├── /feat-143-sentinel-sse
 │   │   ├── /feat-36-judgment-day
 │   │   ├── /fix
+│   │   ├── /fix-152-filesystem-root-bug
 │   │   ├── /issue-114-operations-chief
 │   │   ├── /issue-144-redis-janitor
 │   │   ├── /optimize-entry-flow

--- a/backend/src/tests/fs_root.test.ts
+++ b/backend/src/tests/fs_root.test.ts
@@ -1,0 +1,25 @@
+import { validatePath } from "../tools/fs.js";
+import path from "path";
+import { describe, it, expect } from '@jest/globals';
+
+describe("Filesystem Root Validation", () => {
+  it("debe resolver la raíz del proyecto correctamente", () => {
+    const resolved = validatePath(".");
+    
+    // Si estamos en el monorepo 'Agentes Personales', la ruta resuelta
+    // debería contener ese nombre y NO subir un nivel por encima de él.
+    // El bug actual hace path.resolve(process.cwd(), "..") que sube de más si estamos en la raíz.
+    
+    const currentCwd = process.cwd();
+    console.log(`DEBUG: CWD actual: ${currentCwd}`);
+    console.log(`DEBUG: Ruta resuelta por validatePath('.'): ${resolved}`);
+    
+    // Si corremos los tests desde la raíz del monorepo (como lo hace turbo):
+    // CWD = /.../Agentes Personales
+    // PROJECT_ROOT actual = /.../Agentes Personales/.. = /.../
+    // Esto es INCORRECTO.
+    
+    expect(resolved).toContain("Agentes Personales");
+    expect(resolved.endsWith("Agentes Personales")).toBe(true);
+  });
+});

--- a/backend/src/tools/fs.ts
+++ b/backend/src/tools/fs.ts
@@ -2,15 +2,18 @@ import { tool } from "@langchain/core/tools";
 import { z } from "zod";
 import fs from "fs/promises";
 import path from "path";
+import { fileURLToPath } from "url";
 
-// Definimos la raíz del proyecto para el sandboxing
-// Asumimos que el agente opera desde la raíz del monorepo
-const PROJECT_ROOT = path.resolve(process.cwd(), ".."); 
+// Definimos la raíz del proyecto para el sandboxing de forma robusta
+// fs.ts está en backend/src/tools/, por lo que subimos 3 niveles para llegar a la raíz del monorepo
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const PROJECT_ROOT = path.resolve(__dirname, "..", "..", ".."); 
 
 /**
  * Valida que una ruta esté dentro de los límites del proyecto.
  */
-function validatePath(targetPath: string) {
+export function validatePath(targetPath: string) {
   const resolved = path.resolve(PROJECT_ROOT, targetPath);
   if (!resolved.startsWith(PROJECT_ROOT)) {
     throw new Error(`Acceso denegado: La ruta ${targetPath} está fuera de los límites del proyecto.`);

--- a/openspec/changes/fix-152-filesystem-root-bug/design.md
+++ b/openspec/changes/fix-152-filesystem-root-bug/design.md
@@ -1,0 +1,32 @@
+# Diseño Técnico: Resolución de Raíz Robusta (Issue #152)
+
+## Arquitectura de Solución
+Se implementará una resolución de `PROJECT_ROOT` basada en la ubicación física del archivo `fs.ts`.
+
+### Componentes Afectados
+`backend/src/tools/fs.ts`
+
+### Implementación
+```typescript
+import { fileURLToPath } from 'url';
+import path from 'path';
+
+// Obtenemos la ruta absoluta de este archivo
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+// Subimos desde src/tools/ hasta la raíz del monorepo
+// 1. tools -> src
+// 2. src -> backend
+// 3. backend -> root
+const PROJECT_ROOT = path.resolve(__dirname, "..", "..", "..");
+```
+
+## Alternativa Descartada: Variable de Entorno
+Se descartó depender únicamente de `.env` porque obligaría a todos los desarrolladores y entornos de CI a configurar manualmente la ruta absoluta, lo cual es propenso a errores. La resolución relativa al archivo es automática.
+
+## Impacto en el Estado
+No hay impacto en el `AgentStateType`. Es un cambio puramente de infraestructura de herramientas (tools).
+
+## Pruebas de Resiliencia
+Se verificará que `path.resolve` maneje correctamente los separadores de ruta en Mac/Linux (el SO actual es Mac).

--- a/openspec/changes/fix-152-filesystem-root-bug/exploration.md
+++ b/openspec/changes/fix-152-filesystem-root-bug/exploration.md
@@ -1,0 +1,32 @@
+# Exploración: Bug #152 - PROJECT_ROOT Incorrecto en fs.ts
+
+## Problema
+El worker de filesystem en `backend/src/tools/fs.ts` utiliza una definición estática de `PROJECT_ROOT` basada en `process.cwd()`:
+
+```typescript
+const PROJECT_ROOT = path.resolve(process.cwd(), ".."); 
+```
+
+Esto falla si el backend se ejecuta desde la raíz del monorepo (usando `npm run dev` que invoca `turbo`), ya que `..` subiría un nivel por encima del repositorio. Si se ejecuta desde la carpeta `backend/`, funciona correctamente para el monorepo.
+
+## Hallazgos
+- `process.cwd()` es volátil dependiendo de cómo se inicie el proceso.
+- El sandboxing de `validatePath` depende de que `PROJECT_ROOT` sea siempre la raíz del monorepo.
+- En `package.json` de la raíz, `dev:backend` hace `npm run dev --prefix backend`, lo cual usualmente no cambia el CWD a menos que el script de destino lo haga.
+
+## Alternativas de Solución
+1. **Detección dinámica**: Buscar un archivo marcador (como `package.json` con el nombre del monorepo o `.git`) hacia arriba.
+2. **Variable de Entorno**: Definir `PROJECT_ROOT` en el `.env` y usar un fallback.
+3. **Localización Relativa al Archivo**: Usar `import.meta.url` para encontrar la raíz basándose en la posición de `fs.ts` dentro de la estructura de carpetas.
+
+## Recomendación
+La opción 3 es la más robusta en entornos de desarrollo ya que no depende del CWD. Dado que `fs.ts` está en `backend/src/tools/fs.ts`, la raíz del monorepo está a 3 niveles arriba (`../../../`).
+
+```typescript
+const __dirname = path.dirname(new URL(import.meta.url).pathname);
+const PROJECT_ROOT = path.resolve(__dirname, "..", "..", "..");
+```
+
+## Próximos Pasos
+- Verificar la ubicación exacta de `fs.ts` en todos los entornos.
+- Crear un test que valide `validatePath` con diferentes rutas simuladas.

--- a/openspec/changes/fix-152-filesystem-root-bug/proposal.md
+++ b/openspec/changes/fix-152-filesystem-root-bug/proposal.md
@@ -1,0 +1,27 @@
+# Propuesta: Arreglar Definición de PROJECT_ROOT en fs.ts (Issue #152)
+
+## Intento
+Corregir la resolución de la raíz del proyecto en las herramientas de filesystem para asegurar que el sandboxing funcione correctamente sin importar el directorio de trabajo actual (CWD).
+
+## Alcance
+- **Modificar**: `backend/src/tools/fs.ts`.
+- **Afecta**: Todas las herramientas de filesystem (`list_dir`, `read_file`, `write_file`, `patch_file`).
+
+## Enfoque Propuesto
+Usar `import.meta.url` para derivar `PROJECT_ROOT` de forma relativa a la ubicación del archivo en el disco, en lugar de confiar en `process.cwd()`.
+
+```typescript
+const __filename = new URL(import.meta.url).pathname;
+const __dirname = path.dirname(__filename);
+// fs.ts está en backend/src/tools/
+// Subimos 3 niveles: tools -> src -> backend -> root
+const PROJECT_ROOT = path.resolve(__dirname, "..", "..", "..");
+```
+
+## Riesgos
+- **Entornos Productivos**: Si el código se compila o se empaqueta de forma que la estructura de carpetas cambie (ej: `dist/`), la resolución relativa podría fallar.
+- **Solución**: Agregar un chequeo que verifique la existencia de `package.json` o usar una variable de entorno `APP_ROOT` como prioridad.
+
+## Plan de Verificación
+1. **Tests Unitarios**: Crear `backend/src/tests/fs_root.test.ts` que intente listar la raíz usando la herramienta y verifique que no lance errores de acceso denegado.
+2. **Validación de CWD**: Ejecutar el test desde la raíz del monorepo y desde la carpeta `backend/`.

--- a/openspec/changes/fix-152-filesystem-root-bug/spec.md
+++ b/openspec/changes/fix-152-filesystem-root-bug/spec.md
@@ -1,0 +1,29 @@
+# Especificación: Arreglar PROJECT_ROOT (Issue #152)
+
+## Requerimientos
+
+### 1. Resolución Absoluta de Raíz
+El sistema MUST identificar la raíz del monorepo de forma consistente independientemente de si el proceso se inicia desde `/` o desde `/backend`.
+
+### 2. Sandboxing de Filesystem
+La función `validatePath` MUST permitir el acceso a cualquier archivo dentro del monorepo (incluyendo `ai-engine/`, `frontend/`, `packages/`) y denegar el acceso a cualquier archivo fuera del mismo.
+
+### 3. Compatibilidad con ESM
+La solución MUST ser compatible con módulos ES (ESM), utilizando `import.meta.url` en lugar de `__dirname` global de CommonJS.
+
+## Casos de Prueba (Scenarios)
+
+### Escenario: Validación de Ruta Interna
+- GIVEN un `PROJECT_ROOT` correctamente resuelto.
+- WHEN se llama a `validatePath("package.json")`.
+- THEN la función MUST retornar la ruta absoluta al package.json de la raíz.
+
+### Escenario: Prevención de Path Traversal
+- GIVEN un `PROJECT_ROOT` correctamente resuelto.
+- WHEN se llama a `validatePath("../secrets.txt")`.
+- THEN la función MUST lanzar un error de "Acceso denegado".
+
+### Escenario: Acceso a otros Workspaces
+- GIVEN un `PROJECT_ROOT` correctamente resuelto.
+- WHEN se llama a `validatePath("ai-engine/requirements.txt")`.
+- THEN la función MUST permitir el acceso y retornar la ruta absoluta correcta.

--- a/openspec/changes/fix-152-filesystem-root-bug/tasks.md
+++ b/openspec/changes/fix-152-filesystem-root-bug/tasks.md
@@ -1,0 +1,7 @@
+# Tareas: Arreglar PROJECT_ROOT (Issue #152)
+
+- [x] Crear test de regresión `backend/src/tests/fs_root.test.ts` que valide `validatePath`.
+- [x] Modificar `backend/src/tools/fs.ts` para usar resolución basada en `import.meta.url`.
+- [x] Ejecutar el test desde la raíz y desde `/backend` para confirmar consistencia.
+- [x] Verificar que otras herramientas (read, write, list) siguen funcionando.
+- [x] Commit y Push de la solución.


### PR DESCRIPTION
Resolves issue #152 by implementing a deterministic PROJECT_ROOT resolution based on import.meta.url, ensuring consistent behavior across different execution contexts (root vs workspace).